### PR TITLE
Python 3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ should subclass to implement your pure python jobs. It basically replicates
 the [delayed_job](https://github.com/collectiveidea/delayed_job) Ruby gem behavior.
 
 ## Installation
-
+### From Pypi:
     pip install rubydj-pyworker
+### From Github branch:
+    pip install git+https://github.com/rayyansys/pyworker.git@<branch_name>#egg=rubydj-pyworker
 
 ## Usage
 

--- a/pyworker/db.py
+++ b/pyworker/db.py
@@ -1,4 +1,9 @@
-from urllib.parse import urlparse, parse_qs
+import sys
+major_version = sys.version_info.major
+if major_version == 2:
+    from urlparse import urlparse, parse_qs
+elif major_version == 3:
+    from urllib.parse import urlparse, parse_qs
 import psycopg2
 
 class DBConnector(object):

--- a/pyworker/db.py
+++ b/pyworker/db.py
@@ -1,4 +1,4 @@
-from urlparse import urlparse, parse_qs
+from urllib.parse import urlparse, parse_qs
 import psycopg2
 
 class DBConnector(object):

--- a/pyworker/job.py
+++ b/pyworker/job.py
@@ -1,6 +1,6 @@
 import re
 import yaml
-from util import get_current_time, get_time_delta
+from pyworker.util import get_current_time, get_time_delta
 
 _job_class_registry = {}
 

--- a/pyworker/logger.py
+++ b/pyworker/logger.py
@@ -6,22 +6,22 @@ class Logger(object):
         try:
             self.logger.debug(message)
         except:
-            print "DEBUG: %s" % message
+            print("DEBUG: %s" % message)
 
     def info(self, message):
         try:
             self.logger.info(message)
         except:
-            print "INFO: %s" % message
+            print("INFO: %s" % message)
 
     def warning(self, message):
         try:
             self.logger.warning(message)
         except:
-            print "WARNING: %s" % message
+            print("WARNING: %s" % message)
 
     def error(self, message):
         try:
             self.logger.error(message)
         except:
-            print "ERROR: %s" % message
+            print("ERROR: %s" % message)

--- a/pyworker/worker.py
+++ b/pyworker/worker.py
@@ -26,9 +26,9 @@ class Worker(object):
     @contextmanager
     def _time_limit(self, seconds):
         def signal_handler(signum, frame):
-            raise TimeoutException, 'Execution expired. Either do ' + \
-                'the job faster or raise max_run_time > %d seconds' % \
-                self.max_run_time
+            raise TimeoutException(('Execution expired. Either do ' + \
+                'the job faster or raise max_run_time > %d seconds') % \
+                self.max_run_time)
         signal.signal(signal.SIGALRM, signal_handler)
         signal.alarm(seconds)
         try:

--- a/pyworker/worker.py
+++ b/pyworker/worker.py
@@ -1,7 +1,7 @@
 import os, sys, signal, traceback
 import time
 from contextlib import contextmanager
-from db import DBConnector
+from pyworker.db import DBConnector
 from job import Job
 from logger import Logger
 from util import get_current_time, get_time_delta

--- a/pyworker/worker.py
+++ b/pyworker/worker.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 from pyworker.db import DBConnector
 from pyworker.job import Job
 from logger import Logger
-from util import get_current_time, get_time_delta
+from pyworker.util import get_current_time, get_time_delta
 
 class TimeoutException(Exception): pass
 class TerminatedException(Exception): pass

--- a/pyworker/worker.py
+++ b/pyworker/worker.py
@@ -2,7 +2,7 @@ import os, sys, signal, traceback
 import time
 from contextlib import contextmanager
 from pyworker.db import DBConnector
-from job import Job
+from pyworker.job import Job
 from logger import Logger
 from util import get_current_time, get_time_delta
 

--- a/pyworker/worker.py
+++ b/pyworker/worker.py
@@ -3,7 +3,7 @@ import time
 from contextlib import contextmanager
 from pyworker.db import DBConnector
 from pyworker.job import Job
-from logger import Logger
+from pyworker.logger import Logger
 from pyworker.util import get_current_time, get_time_delta
 
 class TimeoutException(Exception): pass

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requirements = [
 
 setup(
     name = "rubydj-pyworker",
-    version = '0.1.0',
+    version = '1.0.0',
     description="A pure Python worker for Ruby-based DelayedJobs",
     author="Hossam Hammady",
     author_email="github@hammady.net",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requirements = [
 
 setup(
     name = "rubydj-pyworker",
-    version = '1.0.0',
+    version = '0.2.0',
     description="A pure Python worker for Ruby-based DelayedJobs",
     author="Hossam Hammady",
     author_email="github@hammady.net",


### PR DESCRIPTION
Closes #6.
This PR resolves:
1. The [renaming](https://github.com/FriendCode/gittle/issues/49) of `urlparse` module to `urllib.parse` in Python 3. The PR imports the suitable lib based on the python version.
2. Python 3 relative imports should be explicit, not implicit relative imports as it was allowed in Python 2
3. Fix Unsupported Syntax of `print()` and `raise()` functions.

This PR is tested against Python 2 and Python 3.
