### PR TITLE
Feat: Integrate New Relic

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ Example job:
             self.logger.debug("Running MyJob.success hook")
 
         # optional
-        def error(self):
+        def error(self, error):
             self.logger.debug("Running MyJob.error hook")
 
         # optional
-        def failure(self):
+        def failure(self, error):
             self.logger.debug("Running MyJob.failure hook")
 
 Once this example job is declared, the worker can recognize it and

--- a/pyworker/job.py
+++ b/pyworker/job.py
@@ -18,7 +18,7 @@ class Meta(type):
 class Job(object, metaclass=Meta):
     """docstring for Job"""
     def __init__(self, class_name, database, logger,
-        job_id, attempts=0, max_attempts=1, attributes=None):
+        job_id, run_at, queue, attempts=0, max_attempts=1, attributes=None):
         super(Job, self).__init__()
         self.class_name = class_name
         self.database = database
@@ -27,6 +27,8 @@ class Job(object, metaclass=Meta):
         self.attempts = attempts
         self.max_attempts = max_attempts
         self.attributes = attributes
+        self.run_at = run_at
+        self.queue = queue
 
     def __str__(self):
         return "%s: %s" % (self.__class__.__name__, str(self.__dict__))
@@ -56,7 +58,7 @@ class Job(object, metaclass=Meta):
                     attributes.append(line)
             return attributes
 
-        job_id, attempts, handler = job_row
+        job_id, attempts, handler, run_at, queue = job_row
         handler = handler.splitlines()
 
         class_name = extract_class_name(handler[1])
@@ -65,7 +67,7 @@ class Job(object, metaclass=Meta):
             target_class = _job_class_registry[class_name]
         except KeyError:
             return Job(class_name=class_name, logger=logger,
-                max_attempts=max_attempts,
+                max_attempts=max_attempts, run_at=run_at, queue=queue,
                 job_id=job_id, attempts=attempts, database=database)
 
         attributes = extract_attributes(handler[2:])
@@ -77,7 +79,7 @@ class Job(object, metaclass=Meta):
 
         return target_class(class_name=class_name, logger=logger,
             job_id=job_id, attempts=attempts, database=database,
-            max_attempts=max_attempts,
+            max_attempts=max_attempts, run_at=run_at, queue=queue,
             attributes=payload['object']['attributes'])
 
     def before(self):


### PR DESCRIPTION
Integrated New Relic and added 3 custom metrics:
1) Custom/DelayedJobQueueLatency/<job.queue> => latency
2) Custom/DelayedJobQueueLatency/<job.name> => latency
3) Custom/DelayedJobAttemps/<job.name> => attempts

The screenshots are the results of consuming 1K jobs (all enqueued at the same time), single worker with 1 sec `sleep_delay` and a 20% random error job execution.
Transactions:
![1](https://user-images.githubusercontent.com/16247523/236637985-2adf195f-90af-4d8e-8af8-42206cf669cf.png)
Throughput and Erorr Rate:
![2](https://user-images.githubusercontent.com/16247523/236637984-06242bec-f537-4129-b544-47293495e7a1.png)
Slowest Transactions list:
![3](https://user-images.githubusercontent.com/16247523/236637982-7198e0e4-6057-4d0c-9255-f343c1b204ed.png)

Custom Metrics:
![Screenshot from 2023-05-06 20-00-22](https://user-images.githubusercontent.com/16247523/236637975-07df7f45-9ec1-4821-8774-9389020ade56.png)
![Screenshot from 2023-05-06 20-00-07](https://user-images.githubusercontent.com/16247523/236637976-26d3b458-863c-47f3-8ed8-47593dbd12c8.png)
![Screenshot from 2023-05-06 19-59-48](https://user-images.githubusercontent.com/16247523/236637979-629d1544-4afc-492f-a03e-b910af088b32.png)

