### PR TITLE
Integrate NewRelic Instrumentation

### DIFF
--- a/pyworker/job.py
+++ b/pyworker/job.py
@@ -18,13 +18,15 @@ class Meta(type):
 class Job(object, metaclass=Meta):
     """docstring for Job"""
     def __init__(self, class_name, database, logger,
-        job_id, attempts=0, max_attempts=1, attributes=None):
+        job_id, queue, run_at, attempts=0, max_attempts=1, attributes=None):
         super(Job, self).__init__()
         self.class_name = class_name
         self.database = database
         self.logger = logger
         self.job_id = job_id
         self.attempts = attempts
+        self.run_at = run_at
+        self.queue = queue
         self.max_attempts = max_attempts
         self.attributes = attributes
 
@@ -56,7 +58,7 @@ class Job(object, metaclass=Meta):
                     attributes.append(line)
             return attributes
 
-        job_id, attempts, handler = job_row
+        job_id, attempts, run_at, queue, handler = job_row
         handler = handler.splitlines()
 
         class_name = extract_class_name(handler[1])
@@ -66,7 +68,8 @@ class Job(object, metaclass=Meta):
         except KeyError:
             return Job(class_name=class_name, logger=logger,
                 max_attempts=max_attempts,
-                job_id=job_id, attempts=attempts, database=database)
+                job_id=job_id, attempts=attempts,
+                run_at=run_at, queue=queue, database=database)
 
         attributes = extract_attributes(handler[2:])
         logger.debug("Found attributes: %s" % str(attributes))
@@ -76,7 +79,8 @@ class Job(object, metaclass=Meta):
         logger.debug("payload object: %s" % str(payload))
 
         return target_class(class_name=class_name, logger=logger,
-            job_id=job_id, attempts=attempts, database=database,
+            job_id=job_id, attempts=attempts,
+            run_at=run_at, queue=queue, database=database,
             max_attempts=max_attempts,
             attributes=payload['object']['attributes'])
 

--- a/pyworker/worker.py
+++ b/pyworker/worker.py
@@ -89,7 +89,7 @@ class Worker(object):
                 newrelic.agent.record_custom_metrics([
                     ('Custom/DelayedJobQueueLatency/%s' % job.queue, latency),
                     ('Custom/DelayedJobLatency/%s' % job.class_name, latency),
-                    ('Custom/DelayedJobAttempts/%s' % job.class_name, job.attempts + 1)  # Add 1 since it 0-index
+                    ('Custom/DelayedJobAttempts/%s' % job.class_name, job.attempts)
                 ], application=self.newrelic_app)
 
                 yield task

--- a/pyworker/worker.py
+++ b/pyworker/worker.py
@@ -1,5 +1,8 @@
+import newrelic.agent
+
 import os, sys, signal, traceback
 import time
+from datetime import datetime, timezone
 from contextlib import contextmanager
 from pyworker.db import DBConnector
 from pyworker.job import Job
@@ -22,6 +25,17 @@ class Worker(object):
         hostname = os.uname()[1]
         pid = os.getpid()
         self.name = 'host:%s pid:%d' % (hostname, pid)
+
+        # Configure NewRelic if ENV variables set
+        self.newrelic_app = None
+        NEW_RELIC_LICENSE_KEY = os.environ.get("NEW_RELIC_LICENSE_KEY")
+        NEW_RELIC_APP_NAME = os.environ.get("NEW_RELIC_APP_NAME")
+
+        # Register Application in NewRelic if configured
+        if NEW_RELIC_LICENSE_KEY and NEW_RELIC_APP_NAME:
+            self.logger.info('Initializing NewRelic Agent for: %s' % NEW_RELIC_APP_NAME)
+            newrelic.agent.initialize()
+            self.newrelic_app = newrelic.agent.register_application()
 
     @contextmanager
     def _time_limit(self, seconds):
@@ -46,6 +60,42 @@ class Worker(object):
         signal.signal(signal.SIGTERM, signal_handler)
         yield
 
+    @contextmanager
+    def _instrument(self, job, start_time):
+
+        def _latency(run_at, ran_at):
+
+            # Specify UTC timezone and convert to unix time
+            run_at_utc = run_at.replace(tzinfo=timezone.utc)
+            run_at_time = run_at_utc.timestamp()
+
+            # Difference between when the job was scheduled `run_at`
+            # and when the job actually started running `ran_at`
+            return ran_at - run_at_time
+
+        if self.newrelic_app:
+
+            latency = _latency(job.run_at, start_time)
+
+            with newrelic.agent.BackgroundTask(
+                    application=self.newrelic_app,
+                    name='%s#run' % job.class_name,
+                    group='DelayedJob') as task:
+
+                # Record a custom metrics
+                # 1) Custom/DelayedJobQueueLatency/<job.queue> => latency
+                # 2) Custom/DelayedJobLatency/<job.name> => latency
+                # 3) Custom/DelayedJobAttempts/<job.name> => attempts
+                newrelic.agent.record_custom_metrics([
+                    ('Custom/DelayedJobQueueLatency/%s' % job.queue, latency),
+                    ('Custom/DelayedJobLatency/%s' % job.class_name, latency),
+                    ('Custom/DelayedJobAttempts/%s' % job.class_name, job.attempts + 1)  # Add 1 since it 0-index
+                ], application=self.newrelic_app)
+
+                yield task
+        else:
+            yield
+
     def run(self):
         # continuously check for new jobs on specified queue from db
         self._cursor = self.database.connect().cursor()
@@ -60,13 +110,14 @@ class Worker(object):
                         raise ValueError(('Unsupported Job: %s, please import it ' \
                             + 'before you can handle it') % job.class_name)
                     elif job is not None:
-                        self.logger.info('Running Job %d' % job.job_id)
-                        with self._time_limit(self.max_run_time):
-                            job.before()
-                            job.run()
-                            job.after()
-                        job.success()
-                        job.remove()
+                        with self._instrument(job, start_time):
+                            self.logger.info('Running Job %d' % job.job_id)
+                            with self._time_limit(self.max_run_time):
+                                job.before()
+                                job.run()
+                                job.after()
+                            job.success()
+                            job.remove()
                     time.sleep(self.sleep_delay)
                 except Exception as exception:
                     if job is not None:
@@ -81,6 +132,10 @@ class Worker(object):
                             (job.job_id, time_diff))
             
             self.database.disconnect()
+
+            # If configured shutdown NewRelic Agent to upload data on shutdown
+            if self.newrelic_app:
+                newrelic.agent.shutdown_agent()
 
     def get_job(self):
         def get_job_row():
@@ -97,7 +152,7 @@ class Worker(object):
                 OR locked_by = '%s') AND failed_at IS NULL)
                 AND delayed_jobs.queue IN (%s)
             ORDER BY priority ASC, run_at ASC LIMIT 1 FOR UPDATE) RETURNING
-                id, attempts, handler
+                id, attempts, run_at, queue, handler
             ''' % (now, self.name, now, expired, self.name, queues)
             self.logger.debug('query: %s' % query)
             self._cursor.execute(query)

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ six==1.10.0
 Unidecode==0.4.20
 zope.index==4.3.0
 zope.interface==4.4.1
+newrelic==8.8.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ from setuptools import setup
 requirements = [
     'psycopg2',
     'python-dateutil',
-    'PyYAML'
+    'PyYAML',
+    'newrelic'
 ]
 
 setup(


### PR DESCRIPTION
This PR integrates NewRelic instrumentation into the worker. If the user defines the following Environment Variables it will automatically by activated, otherwise it will proceed to run normally without any changes:

- **NEW_RELIC_LICENSE_KEY**
- **NEW_RELIC_APP_NAME**

I make use of `contextmanager` to achieve this, similar to the existing codebase. I've also included extra fields to be returned in the DB query, `ran_at` and `queue` this is so we can send Custom Metrics to NewRelic. 

## Demo

I've built a demo Ruby on Rails [application](https://github.com/yusuf-musleh/scientific-app) that has delayed jobs and a Python [application](https://github.com/yusuf-musleh/scientific-jobs) that runs this worker to process the jobs enqueued from the application. I set the jobs to fail around 5% of the time to simulate real failures.

Here's a quick demo of it working together, along with screenshots from the NewRelic Dashboard including the custom metrics:

![demo-gif2](https://user-images.githubusercontent.com/6829768/236696456-9f4e1880-210c-4b69-89f8-27073689b707.gif)


### NewRelic Dashboards

<img width="1716" alt="Screen Shot 2023-05-07 at 7 00 11 PM" src="https://user-images.githubusercontent.com/6829768/236696527-d7eba210-7d9f-4de0-89e2-b5858bc4004c.png">

<img width="1712" alt="Screen Shot 2023-05-07 at 7 00 24 PM" src="https://user-images.githubusercontent.com/6829768/236696543-b729e248-dfa9-43e0-9204-273abc948673.png">
