### PR TITLE
Fix latency calculation for Python 2.7 & rename metrics

### DIFF
--- a/pyworker/job.py
+++ b/pyworker/job.py
@@ -35,7 +35,7 @@ class Job(object, metaclass=Meta):
 
     @classmethod
     def from_row(cls, job_row, max_attempts, database, logger):
-        '''job_row is a tuple of (id, attempts, handler)'''
+        '''job_row is a tuple of (id, attempts, run_at, queue, handler)'''
         def extract_class_name(line):
             # TODO cache regex
             regex = re.compile('object: !ruby/object:(.+)')

--- a/pyworker/util.py
+++ b/pyworker/util.py
@@ -1,3 +1,4 @@
+import time
 import datetime
 import dateutil.relativedelta
 
@@ -8,3 +9,8 @@ def get_current_time():
 def get_time_delta(**kwargs):
     return dateutil.relativedelta.relativedelta(**kwargs)
 
+def time_string_to_epoch(string, format):
+    return time.mktime(time.strptime(string, format))
+
+def datetime_to_epoch(dt):
+    return time.mktime(dt.timetuple())

--- a/pyworker/util.py
+++ b/pyworker/util.py
@@ -8,9 +8,3 @@ def get_current_time():
 
 def get_time_delta(**kwargs):
     return dateutil.relativedelta.relativedelta(**kwargs)
-
-def time_string_to_epoch(string, format):
-    return time.mktime(time.strptime(string, format))
-
-def datetime_to_epoch(dt):
-    return time.mktime(dt.timetuple())

--- a/pyworker/worker.py
+++ b/pyworker/worker.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from pyworker.db import DBConnector
 from pyworker.job import Job
 from pyworker.logger import Logger
-from pyworker.util import get_current_time, get_time_delta, time_string_to_epoch, datetime_to_epoch
+from pyworker.util import get_current_time, get_time_delta
 
 class TimeoutException(Exception): pass
 class TerminatedException(Exception): pass

--- a/pyworker/worker.py
+++ b/pyworker/worker.py
@@ -63,17 +63,14 @@ class Worker(object):
     def _instrument(self, job):
 
         def _latency(job_run_at):
-
-            desired_start_time = time_string_to_epoch(job_run_at, '%Y-%m-%d %H:%M:%S.%f')
             # we stick to get_current_time() to match the one used in the UPDATE query
-            now = datetime_to_epoch(get_current_time())
+            now = get_current_time()
 
             # Difference between when the job was scheduled `desired_start_time`
             # and when the job actually started running `actual_start_datetime`
-            return now - desired_start_time
+            return (now - job_run_at).total_seconds()
 
         if self.newrelic_app:
-
             latency = _latency(job.run_at)
 
             with newrelic.agent.BackgroundTask(

--- a/pyworker/worker.py
+++ b/pyworker/worker.py
@@ -80,12 +80,12 @@ class Worker(object):
 
                 # Record a custom metrics
                 # 1) Custom/DelayedJobQueueLatency/<job.queue> => latency
-                # 2) Custom/DelayedJobLatency/<job.name> => latency
-                # 3) Custom/DelayedJobAttempts/<job.name> => attempts
+                # 2) Custom/DelayedJobMethodLatency/<job.name> => latency
+                # 3) Custom/DelayedJobMethodAttempts/<job.name> => attempts
                 newrelic.agent.record_custom_metrics([
                     ('Custom/DelayedJobQueueLatency/%s' % job.queue, latency),
-                    ('Custom/DelayedJobLatency/%s' % job.class_name, latency),
-                    ('Custom/DelayedJobAttempts/%s' % job.class_name, job.attempts)
+                    ('Custom/DelayedJobMethodLatency/%s' % job.class_name, latency),
+                    ('Custom/DelayedJobMethodAttempts/%s' % job.class_name, job.attempts)
                 ], application=self.newrelic_app)
 
                 yield task

--- a/pyworker/worker.py
+++ b/pyworker/worker.py
@@ -66,8 +66,8 @@ class Worker(object):
             # we stick to get_current_time() to match the one used in the UPDATE query
             now = get_current_time()
 
-            # Difference between when the job was scheduled `desired_start_time`
-            # and when the job actually started running `actual_start_datetime`
+            # Difference between when the job was scheduled `job_run_at`
+            # and when the job actually started running `now`
             return (now - job_run_at).total_seconds()
 
         if self.newrelic_app:


### PR DESCRIPTION
The previous expressions for latency calculation relied on the `timezone` module which is not available in Python 2.7.
It is not required because `run_at` is already saved in UTC and the current time is assumed to be in UTC because it is used as is in the SQL query to compare it to the `run_at` of jobs to pick.
Additionally, custom metrics were renamed to match existing dashboard queries.
