### PR TITLE
Move worker sleep time out of job context

### DIFF
--- a/pyworker/worker.py
+++ b/pyworker/worker.py
@@ -129,9 +129,8 @@ class Worker(object):
                 # Sleep for a while between each job and break if received SIGTERM
                 try:
                     time.sleep(self.sleep_delay)
-                except Exception as exception:
-                    if type(exception) == TerminatedException:
-                        break
+                except TerminatedException:
+                    break
 
             self.database.disconnect()
 

--- a/pyworker/worker.py
+++ b/pyworker/worker.py
@@ -114,7 +114,6 @@ class Worker(object):
                                 job.after()
                             job.success()
                             job.remove()
-                    time.sleep(self.sleep_delay)
                 except Exception as exception:
                     if job is not None:
                         error_str = traceback.format_exc()
@@ -126,6 +125,13 @@ class Worker(object):
                         time_diff = time.time() - start_time
                         self.logger.info('Job %d finished in %d seconds' % \
                             (job.job_id, time_diff))
+
+                # Sleep for a while between each job and break if received SIGTERM
+                try:
+                    time.sleep(self.sleep_delay)
+                except Exception as exception:
+                    if type(exception) == TerminatedException:
+                        break
 
             self.database.disconnect()
 


### PR DESCRIPTION
Successful jobs marked as failed due to SIGTERM during worker sleep time.
Moved the sleeping time outside the job context.