### PR TITLE
Fix integration bugs + add report_raw and flatten dicts

### DIFF
--- a/pyworker/reporter.py
+++ b/pyworker/reporter.py
@@ -33,8 +33,8 @@ class Reporter(object):
     def shutdown(self):
         newrelic.agent.shutdown_agent()
 
-    def record_exception(self, exception):
-        newrelic.agent.record_exception(exception)
+    def record_exception(self, exc_info):
+        newrelic.agent.notice_error(error=exc_info)
 
     def _format_attributes(self, attributes):
         # prefix then convert all attribute keys to camelCase

--- a/pyworker/reporter.py
+++ b/pyworker/reporter.py
@@ -16,15 +16,19 @@ class Reporter(object):
     def report(self, **attributes):
         # format attributes
         attributes = self._format_attributes(attributes)
+        self.report_raw(**attributes)
+
+    def report_raw(self, **attributes):
         # report to NewRelic
         self._report_newrelic(attributes)
 
     @contextmanager
     def recorder(self, name):
-        return newrelic.agent.BackgroundTask(
-            application=self._newrelic_app,
-            name=name,
-            group='DelayedJob')
+        with newrelic.agent.BackgroundTask(
+                application=self._newrelic_app,
+                name=name,
+                group='DelayedJob') as task:
+            yield task
 
     def shutdown(self):
         newrelic.agent.shutdown_agent()

--- a/pyworker/reporter.py
+++ b/pyworker/reporter.py
@@ -14,6 +14,8 @@ class Reporter(object):
         self._newrelic_app = newrelic.agent.register_application()
 
     def report(self, **attributes):
+        # flatten attributes
+        attributes = self._flatten_attributes(attributes)
         # format attributes
         attributes = self._format_attributes(attributes)
         self.report_raw(**attributes)
@@ -35,6 +37,17 @@ class Reporter(object):
 
     def record_exception(self, exc_info):
         newrelic.agent.notice_error(error=exc_info)
+
+    def _flatten_attributes(self, attributes):
+        # flatten nested dict attributes
+        flattened_attributes = {}
+        for key, value in attributes.items():
+            if type(value) == dict:
+                for nested_key, nested_value in value.items():
+                    flattened_attributes[nested_key] = nested_value
+            else:
+                flattened_attributes[key] = value
+        return flattened_attributes
 
     def _format_attributes(self, attributes):
         # prefix then convert all attribute keys to camelCase

--- a/pyworker/worker.py
+++ b/pyworker/worker.py
@@ -181,7 +181,8 @@ class Worker(object):
             finally:
                 # report error status
                 if self.reporter:
-                    self.reporter.report(error=error, job_failure=failed)
+                    self.reporter.report_raw(error=error)
+                    self.reporter.report(job_failure=failed)
                     if caught_exception:
                         self.reporter.record_exception(caught_exception)
                 time_diff = time.time() - start_time

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -72,11 +72,12 @@ class TestReporter(TestCase):
     #********** .record_exception tests **********#
 
     @patch('pyworker.reporter.newrelic.agent')
-    def test_reporter_record_exception_calls_newrelic_record_exception(self, newrelic_agent):
+    def test_reporter_record_exception_calls_newrelic_notice_error(self, newrelic_agent):
         reporter = Reporter()
-        reporter.record_exception('test_exception')
+        mock_exc_info = ('test_exception', 'test_value', 'test_traceback')
+        reporter.record_exception(mock_exc_info)
 
-        newrelic_agent.record_exception.assert_called_once_with('test_exception')
+        newrelic_agent.notice_error.assert_called_once_with(error=mock_exc_info)
 
     #********** ._format_attributes tests **********#
 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -38,15 +38,22 @@ class TestReporter(TestCase):
         mock_format_attributes.assert_called_once_with({'test_attribute': 1})
         mock_report_newrelic.assert_called_once_with({'formatted_attribute': '1'})
 
+    #********** .report_raw tests **********#
+
+    @patch('pyworker.reporter.Reporter._report_newrelic')
+    def test_reporter_report_raw_reports_to_newrelic(self, mock_report_newrelic):
+        reporter = Reporter()
+        reporter.report_raw(test_attribute=1)
+
+        mock_report_newrelic.assert_called_once_with({'test_attribute': 1})
+
     #********** .recorder tests **********#
 
     @patch('pyworker.reporter.newrelic.agent')
     def test_reporter_recorder_returns_newrelic_background_task(self, newrelic_agent):
         reporter = Reporter()
-        newrelic_agent.BackgroundTask.return_value = ['background_task'].__iter__()
 
-        with reporter.recorder('test_name') as background_task:
-            self.assertEqual(background_task, 'background_task')
+        with reporter.recorder('test_name'):
             newrelic_agent.BackgroundTask.assert_called_once_with(
                 application=reporter._newrelic_app,
                 name='test_name',

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -144,7 +144,8 @@ class TestWorker(TestCase):
 
         self.assert_instrument_context_reports_custom_attributes(job, reporter)
         reporter.record_exception.assert_called_once()
-        reporter.report.assert_any_call(error=True, job_failure=False)
+        reporter.report.assert_any_call(job_failure=False)
+        reporter.report_raw.assert_any_call(error=True)
 
     @patch('pyworker.worker.get_current_time')
     def test_worker_handle_job_when_job_is_unsupported_type_reports_extra_fields(
@@ -182,7 +183,8 @@ class TestWorker(TestCase):
         self.worker.handle_job(job)
 
         reporter.record_exception.assert_not_called()
-        reporter.report.assert_any_call(error=False, job_failure=False)
+        reporter.report.assert_any_call(job_failure=False)
+        reporter.report_raw.assert_any_call(error=False)
         self.assert_instrument_context_reports_custom_attributes(job, reporter)
 
     def test_worker_handle_job_when_error_sets_error_and_unlocks_job(self):
@@ -210,7 +212,8 @@ class TestWorker(TestCase):
 
         self.assert_instrument_context_reports_custom_attributes(job, reporter)
         reporter.record_exception.assert_called_once()
-        reporter.report.assert_any_call(error=True, job_failure=False)
+        reporter.report.assert_any_call(job_failure=False)
+        reporter.report_raw.assert_any_call(error=True)
         job.remove.assert_not_called()
 
     @patch('pyworker.worker.get_current_time')
@@ -228,7 +231,8 @@ class TestWorker(TestCase):
 
         self.assert_instrument_context_reports_custom_attributes(job, reporter)
         reporter.record_exception.assert_called_once()
-        reporter.report.assert_any_call(error=True, job_failure=True)
+        reporter.report.assert_any_call(job_failure=True)
+        reporter.report_raw.assert_any_call(error=True)
         job.remove.assert_not_called()
 
     def test_worker_handle_job_when_error_is_termination_error_bubbles_up(self):


### PR DESCRIPTION
- This fixes 2 bugs that appeared after doing (manual) integration tests with Newrelic.
- It also introduces a new function to the `Reporter` interface: `report_raw` which allows reporting of raw attribute keys without prefixing or formatting them. This is useful to report standard attributes like the Boolean `error`.
- Finally, it flattens attributes that have values of type `dict`. Useful in reporting enqueue attributes as if they are reported natively from the job.