### PR TITLE
Report Unicode strings as is for python2.7

### DIFF
--- a/pyworker/reporter.py
+++ b/pyworker/reporter.py
@@ -64,7 +64,8 @@ class Reporter(object):
 
     @staticmethod
     def _convert_value(value):
-        if type(value) not in [str, int, float, bool]:
+        # unicode is needed in python2.7 only, otherwise it raises an error
+        if type(value) not in [str, int, float, bool, unicode]:
             return json.dumps(value)
         return value
 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -110,6 +110,7 @@ class TestReporter(TestCase):
         self.assertEqual(
             reporter._format_attributes({
                 'test_key1': 'test_value1',
+                'test_key1b': u'test_value1b', # specific to python 2.7
                 'test_key2': 2,
                 'test_key3': 3.0,
                 'test_key4': True,
@@ -119,6 +120,7 @@ class TestReporter(TestCase):
             }),
             {
                 'prefix.testKey1': 'test_value1',
+                'prefix.testKey1B': u'test_value1b', # specific to python 2.7
                 'prefix.testKey2': 2,
                 'prefix.testKey3': 3.0,
                 'prefix.testKey4': True,
@@ -156,6 +158,11 @@ class TestReporter(TestCase):
         self.assertEqual(
             reporter._convert_value('test_value'),
             'test_value'
+        )
+        # specific to python 2.7
+        self.assertEqual(
+            reporter._convert_value(u'test_value'),
+            u'test_value'
         )
         self.assertEqual(
             reporter._convert_value(1),


### PR DESCRIPTION
In python 2.7, strings are not in Unicode by default. The current code converts them to Unicode before processing. As a result, the `Reporter` class converts those strings to JSON dumped strings before reporting as they don't match the data type `str`.
This PR checks if the type is `unicode` then skips the above conversion in this case.
