### PR TITLE
Create workflows to publish to PyPI (and TestPyPI)

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -1,0 +1,30 @@
+name: Publish to PyPI
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/rubydj-pyworker/
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
+    - name: Build package distributions
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+        python setup.py sdist bdist_wheel
+        twine check dist/*
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        print-hash: true

--- a/.github/workflows/publish-testpypi.yaml
+++ b/.github/workflows/publish-testpypi.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - tasks/6106
 jobs:
   testpypi-publish:
     name: Upload release to TestPyPI

--- a/.github/workflows/publish-testpypi.yaml
+++ b/.github/workflows/publish-testpypi.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - tasks/6106
 jobs:
   testpypi-publish:
     name: Upload release to TestPyPI

--- a/.github/workflows/publish-testpypi.yaml
+++ b/.github/workflows/publish-testpypi.yaml
@@ -1,0 +1,32 @@
+name: Publish to TestPyPI
+on:
+  push:
+    branches:
+      - master
+jobs:
+  testpypi-publish:
+    name: Upload release to TestPyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/rubydj-pyworker/
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
+    - name: Build package distributions
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+        python setup.py sdist bdist_wheel
+        twine check dist/*
+    - name: Publish package distributions to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        skip-existing: true
+        print-hash: true

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [
 
 setup(
     name = "rubydj-pyworker",
-    version = '1.2.0-rc1',
+    version = '1.2.0',
     description="A pure Python worker for Ruby-based DelayedJobs with Newrelic reporting.",
     author="Rayyan Systems, Inc.",
     author_email="support@rayyan.ai",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [
 
 setup(
     name = "rubydj-pyworker",
-    version = '1.1.0',
+    version = '1.2.0',
     description="A pure Python worker for Ruby-based DelayedJobs with Newrelic reporting.",
     author="Rayyan Systems, Inc.",
     author_email="support@rayyan.ai",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [
 
 setup(
     name = "rubydj-pyworker",
-    version = '1.2.0',
+    version = '1.2.0-rc1',
     description="A pure Python worker for Ruby-based DelayedJobs with Newrelic reporting.",
     author="Rayyan Systems, Inc.",
     author_email="support@rayyan.ai",


### PR DESCRIPTION
This creates 2 new workflows which publish a new release to either PyPI or TestPyPI.
A tag starting with `v` triggers the former, while any commit to the `master` branch triggers the latter.
Publishing happens using [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) which requires setup on the repo settings (done already) and on Test/PyPI:
<img width="520" alt="image" src="https://github.com/user-attachments/assets/c52fbacf-ac4f-467e-b06a-c47e638b3640">
A test run can be found [here](https://github.com/rayyansys/pyworker/actions/runs/11562828149).