### PR TITLE
Add support for max_backoff_delay_seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ w.sleep_delay = 3
 w.max_attempts = 5
 
 # sets a cap on how long a worker should wait between retry attempts.
-# if not set, the backoff delay time will grow exponentially (default 60)
+# if not set, the backoff delay time will grow exponentially (minimum is 5)
 w.max_backoff_delay_seconds = 60
 
 # maximum run time allowed for the job, before it expires (default 3600)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ w.sleep_delay = 3
 w.max_attempts = 5
 
 # sets a cap on how long a worker should wait between retry attempts.
-# if not set, the backoff delay time will grow exponentially (default None)
+# if not set, the backoff delay time will grow exponentially (default 60)
 w.max_backoff_delay_seconds = 60
 
 # maximum run time allowed for the job, before it expires (default 3600)

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ w.sleep_delay = 3
 # maximum attempts before marking the job as permanently failing (default 3)
 w.max_attempts = 5
 
+# sets a cap on how long a worker should wait between retry attempts.
+# if not set, the backoff delay time will grow exponentially (default None)
+w.max_backoff_delay_seconds = 60
+
 # maximum run time allowed for the job, before it expires (default 3600)
 w.max_run_time = 14400
 

--- a/pyworker/job.py
+++ b/pyworker/job.py
@@ -42,7 +42,7 @@ class Job(object, metaclass=Meta):
 
     @classmethod
     def from_row(cls, job_row, max_attempts, database, logger,
-                 extra_fields=None, reporter=None):
+                 extra_fields=None, reporter=None, max_backoff_delay_seconds=None):
         '''job_row is a tuple of (id, attempts, run_at, queue, handler, *extra_fields)'''
         def extract_class_name(line):
             regex = re.compile('object: !ruby/object:(.+)')
@@ -85,7 +85,8 @@ class Job(object, metaclass=Meta):
                 job_id=job_id, attempts=attempts,
                 run_at=run_at, queue=queue, database=database,
                 abstract=True, extra_fields=extra_fields_dict,
-                reporter=reporter)
+                reporter=reporter, max_backoff_delay_seconds=max_backoff_delay_seconds
+            )
 
         attributes = extract_attributes(handler[2:])
         logger.debug("Found attributes: %s" % str(attributes))
@@ -100,7 +101,8 @@ class Job(object, metaclass=Meta):
             max_attempts=max_attempts,
             attributes=payload['object']['attributes'],
             abstract=False, extra_fields=extra_fields_dict,
-            reporter=reporter)
+            reporter=reporter, max_backoff_delay_seconds=max_backoff_delay_seconds
+        )
 
     def before(self):
         self.logger.debug("Running Job.before hook")

--- a/pyworker/job.py
+++ b/pyworker/job.py
@@ -28,6 +28,8 @@ class Job(object, metaclass=Meta):
         self.job_id = job_id
         self.job_name = '%s#run' % class_name
         self.attempts = attempts
+        if max_backoff_delay_seconds:
+            max_backoff_delay_seconds = max(max_backoff_delay_seconds, 2) # max_backoff_delay_seconds can not be less than 2 seconds
         self.max_backoff_delay_seconds = max_backoff_delay_seconds
         self.run_at = run_at
         self.queue = queue

--- a/pyworker/job.py
+++ b/pyworker/job.py
@@ -20,7 +20,7 @@ class Job(object, metaclass=Meta):
     def __init__(self, class_name, database, logger,
                  job_id, queue, run_at, attempts=0, max_attempts=1,
                  attributes=None, abstract=False, extra_fields=None,
-                 reporter=None):
+                 reporter=None, max_delta=-1):
         super(Job, self).__init__()
         self.class_name = class_name
         self.database = database
@@ -28,6 +28,7 @@ class Job(object, metaclass=Meta):
         self.job_id = job_id
         self.job_name = '%s#run' % class_name
         self.attempts = attempts
+        self.max_delta = max_delta
         self.run_at = run_at
         self.queue = queue
         self.max_attempts = max_attempts
@@ -145,6 +146,8 @@ class Job(object, metaclass=Meta):
             # set new exponential run_at
             setters.append('run_at = %s')
             delta = (self.attempts**4) + 5
+            if self.max_delta > 0 and delta > self.max_delta:
+                delta = self.max_delta
             values.append(str(now + get_time_delta(seconds=delta)))
 
         self._update_job(setters, values)

--- a/pyworker/job.py
+++ b/pyworker/job.py
@@ -29,7 +29,7 @@ class Job(object, metaclass=Meta):
         self.job_name = '%s#run' % class_name
         self.attempts = attempts
         if max_backoff_delay_seconds:
-            max_backoff_delay_seconds = max(max_backoff_delay_seconds, 2) # max_backoff_delay_seconds can not be less than 2 seconds
+            max_backoff_delay_seconds = max(max_backoff_delay_seconds, 5) # max_backoff_delay_seconds can not be less than 5 seconds
         self.max_backoff_delay_seconds = max_backoff_delay_seconds
         self.run_at = run_at
         self.queue = queue

--- a/pyworker/job.py
+++ b/pyworker/job.py
@@ -20,7 +20,7 @@ class Job(object, metaclass=Meta):
     def __init__(self, class_name, database, logger,
                  job_id, queue, run_at, attempts=0, max_attempts=1,
                  attributes=None, abstract=False, extra_fields=None,
-                 reporter=None, max_delta=-1):
+                 reporter=None, max_backoff_delay_seconds=-1):
         super(Job, self).__init__()
         self.class_name = class_name
         self.database = database
@@ -28,7 +28,7 @@ class Job(object, metaclass=Meta):
         self.job_id = job_id
         self.job_name = '%s#run' % class_name
         self.attempts = attempts
-        self.max_delta = max_delta
+        self.max_backoff_delay_seconds = max_backoff_delay_seconds
         self.run_at = run_at
         self.queue = queue
         self.max_attempts = max_attempts
@@ -146,8 +146,8 @@ class Job(object, metaclass=Meta):
             # set new exponential run_at
             setters.append('run_at = %s')
             delta = (self.attempts**4) + 5
-            if self.max_delta > 0 and delta > self.max_delta:
-                delta = self.max_delta
+            if self.max_backoff_delay_seconds > 0 and delta > self.max_backoff_delay_seconds:
+                delta = self.max_backoff_delay_seconds
             values.append(str(now + get_time_delta(seconds=delta)))
 
         self._update_job(setters, values)

--- a/pyworker/job.py
+++ b/pyworker/job.py
@@ -20,7 +20,7 @@ class Job(object, metaclass=Meta):
     def __init__(self, class_name, database, logger,
                  job_id, queue, run_at, attempts=0, max_attempts=1,
                  attributes=None, abstract=False, extra_fields=None,
-                 reporter=None, max_backoff_delay_seconds=-1):
+                 reporter=None, max_backoff_delay_seconds=None):
         super(Job, self).__init__()
         self.class_name = class_name
         self.database = database
@@ -146,7 +146,7 @@ class Job(object, metaclass=Meta):
             # set new exponential run_at
             setters.append('run_at = %s')
             delta = (self.attempts**4) + 5
-            if self.max_backoff_delay_seconds > 0 and delta > self.max_backoff_delay_seconds:
+            if self.max_backoff_delay_seconds and delta > self.max_backoff_delay_seconds:
                 delta = self.max_backoff_delay_seconds
             values.append(str(now + get_time_delta(seconds=delta)))
 

--- a/pyworker/worker.py
+++ b/pyworker/worker.py
@@ -22,6 +22,7 @@ class Worker(object):
         self.sleep_delay = 10
         self.max_attempts = 3
         self.max_run_time = 3600
+        self.max_backoff_delay_seconds = 60
         self.queue_names = 'default'
         hostname = os.uname()[1]
         pid = os.getpid()
@@ -147,7 +148,8 @@ class Worker(object):
             return Job.from_row(job_row, max_attempts=self.max_attempts,
                 database=self.database, logger=self.logger,
                 extra_fields=self.extra_delayed_job_fields,
-                reporter=self.reporter)
+                reporter=self.reporter, max_backoff_delay_seconds=self.max_backoff_delay_seconds
+            )
         else:
             return None
 

--- a/pyworker/worker.py
+++ b/pyworker/worker.py
@@ -14,7 +14,8 @@ class TerminatedException(Exception): pass
 class Worker(object):
     def __init__(self, dbstring, logger=None,
                  extra_delayed_job_fields=None,
-                 reported_attributes_prefix=''):
+                 reported_attributes_prefix='',
+                 max_backoff_delay_seconds=None):
         super(Worker, self).__init__()
         self.logger = Logger(logger)
         self.logger.info('Starting pyworker...')
@@ -22,7 +23,7 @@ class Worker(object):
         self.sleep_delay = 10
         self.max_attempts = 3
         self.max_run_time = 3600
-        self.max_backoff_delay_seconds = 60
+        self.max_backoff_delay_seconds = max_backoff_delay_seconds
         self.queue_names = 'default'
         hostname = os.uname()[1]
         pid = os.getpid()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -212,21 +212,21 @@ class TestJob(TestCase):
 
     ## run_at
     @patch('pyworker.job.get_current_time')
-    def test_set_error_unlock_if_delta_doesnt_exceed_max_delta(
+    def test_set_error_unlock_if_delta_doesnt_exceed_max_backoff_delay_seconds(
             self, mock_get_current_time):
         mock_get_current_time.return_value = self.mock_now
         job = self.load_registered_job()
-        job.max_delta = 8
+        job.max_backoff_delay_seconds = 8
 
         self.assert_job_updated_run_at(job, attempts=0, expected_value=datetime.datetime(2023, 10, 7, 0, 0, 6))
 
     ## run_at
     @patch('pyworker.job.get_current_time')
-    def test_set_error_unlock_if_delta_exceeds_max_delta(
+    def test_set_error_unlock_if_delta_exceeds_max_backoff_delay_seconds(
             self, mock_get_current_time):
         mock_get_current_time.return_value = self.mock_now
         job = self.load_registered_job()
-        job.max_delta = 2
+        job.max_backoff_delay_seconds = 2
 
         self.assert_job_updated_run_at(job, attempts=0, expected_value=datetime.datetime(2023, 10, 7, 0, 0, 2))
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -32,7 +32,7 @@ class TestJob(TestCase):
         with open('tests/fixtures/%s' % filename) as f:
             return f.read()
 
-    def load_job(self, filename):
+    def load_job(self, filename, max_backoff_delay_seconds=None):
         mock_handler = self.load_fixture(filename)
         mock_row = (
             self.mock_job_id,
@@ -43,7 +43,9 @@ class TestJob(TestCase):
         )
         return Job.from_row(mock_row,
                             self.mock_max_attempts,
-                            MagicMock(), MagicMock())
+                            MagicMock(), MagicMock(),
+                            max_backoff_delay_seconds=max_backoff_delay_seconds
+                        )
 
     def load_job_with_extra_fields(self, filename):
         mock_handler = self.load_fixture(filename)
@@ -71,8 +73,8 @@ class TestJob(TestCase):
         job.reporter = reporter
         return job
 
-    def load_registered_job(self):
-        job = self.load_job('handler_registered.yaml')
+    def load_registered_job(self, max_backoff_delay_seconds=None):
+        job = self.load_job('handler_registered.yaml', max_backoff_delay_seconds=max_backoff_delay_seconds)
         job.error = MagicMock()
         job.failure = MagicMock()
         job._update_job = MagicMock()
@@ -215,8 +217,7 @@ class TestJob(TestCase):
     def test_set_error_unlock_if_delta_doesnt_exceed_max_backoff_delay_seconds(
             self, mock_get_current_time):
         mock_get_current_time.return_value = self.mock_now
-        job = self.load_registered_job()
-        job.max_backoff_delay_seconds = 8
+        job = self.load_registered_job(max_backoff_delay_seconds=8)
 
         self.assert_job_updated_run_at(job, attempts=0, expected_value=datetime.datetime(2023, 10, 7, 0, 0, 6))
 
@@ -225,10 +226,18 @@ class TestJob(TestCase):
     def test_set_error_unlock_if_delta_exceeds_max_backoff_delay_seconds(
             self, mock_get_current_time):
         mock_get_current_time.return_value = self.mock_now
-        job = self.load_registered_job()
-        job.max_backoff_delay_seconds = 2
+        job = self.load_registered_job(max_backoff_delay_seconds=5)
 
-        self.assert_job_updated_run_at(job, attempts=0, expected_value=datetime.datetime(2023, 10, 7, 0, 0, 2))
+        self.assert_job_updated_run_at(job, attempts=0, expected_value=datetime.datetime(2023, 10, 7, 0, 0, 5))
+
+    ## run_at
+    @patch('pyworker.job.get_current_time')
+    def test_set_error_unlock_if_max_backoff_delay_seconds_less_than_minimum(
+            self, mock_get_current_time):
+        mock_get_current_time.return_value = self.mock_now
+        job = self.load_registered_job(max_backoff_delay_seconds=2)
+
+        self.assert_job_updated_run_at(job, attempts=0, expected_value=datetime.datetime(2023, 10, 7, 0, 0, 5))
 
     @patch('pyworker.job.get_current_time')
     def test_set_error_unlock_if_max_attempts_not_exceeded_updates_run_at_exponentially_when_attempts_1(

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -210,6 +210,26 @@ class TestJob(TestCase):
 
         self.assert_job_updated_run_at(job, attempts=0, expected_value=datetime.datetime(2023, 10, 7, 0, 0, 6))
 
+    ## run_at
+    @patch('pyworker.job.get_current_time')
+    def test_set_error_unlock_if_delta_doesnt_exceed_max_delta(
+            self, mock_get_current_time):
+        mock_get_current_time.return_value = self.mock_now
+        job = self.load_registered_job()
+        job.max_delta = 8
+
+        self.assert_job_updated_run_at(job, attempts=0, expected_value=datetime.datetime(2023, 10, 7, 0, 0, 6))
+
+    ## run_at
+    @patch('pyworker.job.get_current_time')
+    def test_set_error_unlock_if_delta_exceeds_max_delta(
+            self, mock_get_current_time):
+        mock_get_current_time.return_value = self.mock_now
+        job = self.load_registered_job()
+        job.max_delta = 2
+
+        self.assert_job_updated_run_at(job, attempts=0, expected_value=datetime.datetime(2023, 10, 7, 0, 0, 2))
+
     @patch('pyworker.job.get_current_time')
     def test_set_error_unlock_if_max_attempts_not_exceeded_updates_run_at_exponentially_when_attempts_1(
             self, mock_get_current_time):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -45,6 +45,7 @@ class TestWorker(TestCase):
         self.assertEqual(worker.sleep_delay, 10)
         self.assertEqual(worker.max_attempts, 3)
         self.assertEqual(worker.max_run_time, 3600)
+        self.assertEqual(worker.max_backoff_delay_seconds, 60)
         self.assertEqual(worker.queue_names, 'default')
         self.assertEqual(worker.name, 'host:localhost pid:1234')
         self.assertIsNone(worker.extra_delayed_job_fields)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -39,7 +39,7 @@ class TestWorker(TestCase):
     @patch('pyworker.worker.os.getpid', return_value=1234)
     @patch('pyworker.worker.DBConnector')
     def test_worker_init(self, mock_db, *_):
-        worker = Worker('dummy')
+        worker = Worker('dummy', max_backoff_delay_seconds=60)
 
         self.assertEqual(worker.database, mock_db.return_value)
         self.assertEqual(worker.sleep_delay, 10)


### PR DESCRIPTION
In some cases we need to set upper limit to the delta growth. A member `max_backoff_delay_seconds` is added to control the delta growth and force saturation